### PR TITLE
Unit tests for signIn and signOut usecases

### DIFF
--- a/test/features/authentication/domain/usecases/sign_in_use_case_test.dart
+++ b/test/features/authentication/domain/usecases/sign_in_use_case_test.dart
@@ -1,0 +1,31 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:temari/features/authentication/domain/entities/user.dart';
+import 'package:temari/features/authentication/domain/usecases/sign_in_use_case.dart';
+
+import 'mock_auth_repo.dart';
+
+void main() {
+  late MockAuthRepo repo;
+  late SignInUseCase useCase;
+  final tUser = User(id: '1', email: 'user@emailcom');
+  Params params = Params(identifier: 'user@email.com', password: '123');
+  setUp(() {
+    repo = MockAuthRepo();
+    useCase = SignInUseCase(repo: repo);
+  });
+
+  test('should call [repo.SignIn] and return with the right data', () async {
+    when(() => repo.signIn(
+            identifier: any(named: 'identifier'),
+            password: any(named: 'password')))
+        .thenAnswer((_) async => Right(tUser));
+    final result = await useCase(params);
+    expect(result, Right(tUser));
+    verify(() => repo.signIn(
+        identifier: any(named: 'identifier'),
+        password: any(named: 'password'))).called(1);
+    verifyNoMoreInteractions(repo);
+  });
+}

--- a/test/features/authentication/domain/usecases/sign_out_use_case_test.dart
+++ b/test/features/authentication/domain/usecases/sign_out_use_case_test.dart
@@ -1,0 +1,23 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:temari/features/authentication/domain/usecases/sign_out_use_case.dart';
+
+import 'mock_auth_repo.dart';
+
+void main() {
+  late MockAuthRepo repo;
+  late SignOutUseCase useCase;
+  setUp(() {
+    repo = MockAuthRepo();
+    useCase = SignOutUseCase(repo: repo);
+  });
+
+  test('should call [repo.signOut] and return with the right data', () async {
+    when(() => repo.signOut()).thenAnswer((_) async => const Right(null));
+    final result = await useCase(NoParams());
+    expect(result, const Right(null));
+    verify(() => repo.signOut()).called(1);
+    verifyNoMoreInteractions(repo);
+  });
+}

--- a/test/features/authentication/domain/usecases/sign_up_use_case_test.dart
+++ b/test/features/authentication/domain/usecases/sign_up_use_case_test.dart
@@ -8,27 +8,21 @@ import 'package:temari/features/authentication/domain/usecases/sign_up_use_case.
 import 'mock_auth_repo.dart';
 
 void main() {
-  late AuthRepo repo;
-  late SignUpUseCase usecase;
-  final params = Params(email: 'email@test.com', password: '123');
-
+  late MockAuthRepo repo;
+  late SignUpUseCase useCase;
+  final tUser = User(id: '1', email: 'user@email.com');
+  Params params = Params(email: 'user@email.com', password: '123');
   setUp(() {
     repo = MockAuthRepo();
-    usecase = SignUpUseCase(repo: repo);
+    useCase = SignUpUseCase(repo: repo);
   });
 
-  test('should call [AuthRepo.signUp] and return with the right data',
-      () async {
-    final tUser = User(id: '123', email: 'test@example.com');
-    when(
-      () => repo.signUp(
-        email: any(named: 'email'),
-        password: any(named: 'password'),
-      ),
-    ).thenAnswer((_) async => Right(tUser));
-
-    final result = await usecase(params);
-    expect(result, equals(Right(tUser)));
+  test('should call [repo.signUp] and return with the right data', () async {
+    when(() => repo.signUp(
+            email: any(named: 'email'), password: any(named: 'password')))
+        .thenAnswer((_) async => Right(tUser));
+    final result = await useCase(params);
+    expect(result, Right(tUser));
     verify(() => repo.signUp(
         email: any(named: 'email'),
         password: any(named: 'password'))).called(1);


### PR DESCRIPTION
This pull request includes several changes to the test cases for the authentication domain use cases. The changes mainly involve the addition of new test cases and the use of a mock repository to ensure the correctness of the use cases.

### Additions and Modifications to Test Cases:

* [`test/features/authentication/domain/usecases/sign_in_use_case_test.dart`](diffhunk://#diff-8dfe414f0ce6f2b050d8352c395f31facab6949a882d5247f6b23f245cfca585R1-R31): Added a new test case for the `SignInUseCase` to verify that the repository's `signIn` method is called with the correct parameters and returns the expected user data.

* [`test/features/authentication/domain/usecases/sign_out_use_case_test.dart`](diffhunk://#diff-7683c0ac95d74c052c03438e8dc97be360137f2362ce855f064cd685f0ab10d5R1-R23): Added a new test case for the `SignOutUseCase` to verify that the repository's `signOut` method is called and returns the expected result.

* [`test/features/authentication/domain/usecases/sign_up_use_case_test.dart`](diffhunk://#diff-6215aa345454ed77075187a982101ca6e7ccab98b90c995afd9dd10e748ca09cL11-R25): Modified the existing test case for the `SignUpUseCase` to use a mock repository and verify that the repository's `signUp` method is called with the correct parameters and returns the expected user data.